### PR TITLE
Gzip for response.

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,7 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path("../config/environment", __FILE__)
+use Rack::Deflater
 map Rails.application.config.relative_url_root || "/" do
   run Rails.application
 end


### PR DESCRIPTION
application.js compiled of webpack is over 2.1M. When puma serve web, It takes too much to download for user for the first time. So gzip contents to reduce downloading time.

Signed-off-by: Yongkwan Kim <yongk.kim@navercorp.com>